### PR TITLE
Keep plasmoid status

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,20 +6,51 @@ Multiple noise components can be combined, controlling their individual volume.
 The applet reads noise files and their icons from a given, customisable folder.
 The noise and the icon must be in the same folder and share the same name,
 except for the file extension.
-Free noises can be found in the [anoise project](http://anoise.tuxfamily.org/).
+
+The plasmoid remembers its state across reboots, including play/pause status,
+volume, and active noise components. To prevent it from playing sound at
+start-up, even if it was still playing at the time of the last shutdown, go to
+the plasmoid settings and tick "Paused at start-up".
+
+Free noises in a ready-to-use format for this plasmoid can be found in the
+[anoise project](http://anoise.tuxfamily.org/).
 
 # Build and install
+
 The applet can be installed locally with
-```
+```bash
 kpackagetool5 -t Plasma/Applet --install plasmoid
 ```
 or globally with
-```
+```bash
 cmake . -DCMAKE_INSTALL_PREFIX=`kf5-config --prefix`
 make
 sudo make install
 ```
-To see the plasmoid, you may need to restart plasmashell.
+
+To see the plasmoid, you may need to restart plasmashell
+```bash
+kquitapp5 plasmashell
+kstart5 plasmashell
+```
+
+# Contribute
+
+Questions, bug reports, and feature requests are welcome. Feel free to open an
+[issue on
+GitHub](https://github.com/m-pilia/plasma-applet-ambientnoise/issues).
+
+New translations are welcome. Translation files are located in the
+[translations folder](translations). To add a new translation:
++ Copy the template
+file `plasma_applet_org.kde.plasma.ambientnoise.pot` to
+`plasma_applet_org.kde.plasma.ambientnoise_XX.po` (where `XX` is the [ISO 639-1
+code](http://www.loc.gov/standards/iso639-2/php/English_list.php) for the
+language you are adding).
++ Fill all the fields inside the file.
++ Commit and open a [pull
+request on
+GitHub](https://github.com/m-pilia/plasma-applet-ambientnoise/pulls).
 
 # License
 The project is licensed under GPL 3. See [LICENSE](./LICENSE)

--- a/plasmoid/contents/config/main.xml
+++ b/plasmoid/contents/config/main.xml
@@ -11,6 +11,21 @@
           <default>30</default>
         </entry>
 
+        <!-- noise components -->
+        <entry name="noiseComponents" type="String">
+          <default>[]</default>
+        </entry>
+
+        <!-- playing status -->
+        <entry name="playing" type="Bool">
+          <default>true</default>
+        </entry>
+
+        <!-- paused at startup -->
+        <entry name="pausedAtStartup" type="Bool">
+          <default>false</default>
+        </entry>
+
         <!-- system noise audio data -->
         <entry name="noiseDataDirectory" type="String">
             <default>/usr/share/anoise/sounds</default>

--- a/plasmoid/contents/js/scripts.js
+++ b/plasmoid/contents/js/scripts.js
@@ -86,3 +86,41 @@ function computeVolume(componentVolume) {
                                       QtMultimedia.LogarithmicVolumeScale,
                                       QtMultimedia.LinearVolumeScale);
 }
+
+/*!
+ * Serialise a QML DataModel object.
+ */
+function serialiseDataModel(dataModel) {
+    var data = [];
+    for (var i = 0; i < dataModel.count; ++i) {
+        data.push(dataModel.get(i));
+    }
+    return JSON.stringify(data);
+}
+
+/*!
+ * Deserialise a QML DataModel object.
+ */
+function deserialiseDataModel(dataString, dataModel) {
+    if (dataString) {
+        dataModel.clear();
+        var data = JSON.parse(dataString);
+        for (var i = 0; i < data.length; ++i) {
+            dataModel.append(data[i]);
+        }
+    }
+}
+
+/*!
+ * Save current noise component settings.
+ */
+function saveComponents() {
+    plasmoid.configuration.noiseComponents = serialiseDataModel(noiseComponentsModel);
+}
+
+/*!
+ * Restore noise components from settings.
+ */
+function restoreComponents() {
+    deserialiseDataModel(plasmoid.configuration.noiseComponents, noiseComponentsModel);
+}

--- a/plasmoid/contents/ui/AddNoisePopup.qml
+++ b/plasmoid/contents/ui/AddNoisePopup.qml
@@ -60,15 +60,19 @@ ScrollView {
                     text: Js.toPrettyName(fileName)
                     Layout.alignment: Qt.AlignVCenter
                 }
+            }
 
-                MouseArea {
-                    anchors.fill: parent
+            MouseArea {
+                anchors.fill: parent
 
-                    onClicked: {
-                        main.playing = true;
-                        noiseComponentsModel.append({ "filename": fileName, });
-                        stack.pop();
-                    }
+                onClicked: {
+                    main.playing = true;
+                    noiseComponentsModel.append({
+                        "_filename": fileName,
+                        "_volume": main.maxVolume,
+                        "_muted": false,
+                    });
+                    stack.pop();
                 }
             }
         }

--- a/plasmoid/contents/ui/settings.qml
+++ b/plasmoid/contents/ui/settings.qml
@@ -29,6 +29,7 @@ Item {
 
     property string defaultNoiseDataDirectory: "/usr/share/anoise/sounds"
     property alias cfg_noiseDataDirectory: noiseData.text
+    property alias cfg_pausedAtStartup: pausedAtStartup.checked
 
     ColumnLayout {
         width: settings.width
@@ -49,11 +50,17 @@ Item {
             /* restore default */
             PlasmaComponents.Button {
                 iconName: "edit-undo"
-                tooltip: "Restore default"
+                tooltip: i18n("Restore default")
                 onClicked: {
                     noiseData.text = defaultNoiseDataDirectory
                 }
             }
+        }
+
+        /* play on startup */
+        PlasmaComponents.CheckBox {
+            id: pausedAtStartup
+            text: i18n("Paused at start-up")
         }
     }
 }

--- a/plasmoid/metadata.desktop
+++ b/plasmoid/metadata.desktop
@@ -2,8 +2,10 @@
 Encoding=UTF-8
 Name=Ambient noise
 Name[it]=Rumore ambientale
+Name[sv]=Omgivande ljud
 Comment=Plasmoid for ambient noise reproduction
 Comment[it]=Plasmoide per la riproduzione di rumore ambientale
+Comment[sv]=Plasmoid som spelar omgivande ljud
 Icon=ambientnoise
 Type=Service
 
@@ -12,7 +14,7 @@ X-KDE-PluginInfo-Email=martino.pilia@gmail.com
 X-KDE-PluginInfo-Website=https://github.com/m-pilia/plasma-applet-ambientnoise
 X-KDE-PluginInfo-License=GPL
 X-KDE-PluginInfo-Name=org.kde.plasma.ambientnoise
-X-KDE-PluginInfo-Version=0.1
+X-KDE-PluginInfo-Version=0.5
 X-KDE-PluginInfo-EnabledByDefault=true
 X-KDE-ServiceTypes=Plasma/Applet
 X-Plasma-API=declarativeappletscript

--- a/translations/extract-messages.sh
+++ b/translations/extract-messages.sh
@@ -1,31 +1,32 @@
 #!/bin/sh
-BASEDIR=".."                                          # root of translatable sources
-PROJECT="plasma_applet_org.kde.plasma.ambientnoise" # project name
-BUGADDR="http://github.com/m-pilia/plasma-applet-ambientnoise/issues"	# MSGID-Bugs
-WDIR="`pwd`/po"		# working dir
+set -euo pipefail
 
+BASEDIR=".."                                                          # root of translatable sources
+PROJECT="plasma_applet_org.kde.plasma.ambientnoise"                   # project name
+BUGADDR="http://github.com/m-pilia/plasma-applet-ambientnoise/issues" # MSGID-Bugs
+WDIR="$(pwd)/po"		                                              # working dir
 
 echo "Extracting messages"
-find ${BASEDIR} -name '*.qml' -o -name '*.js' | sort > ${WDIR}/infiles.list
-cd ${WDIR}
+find ${BASEDIR} -name '*.qml' -o -name '*.js' | sort > "${WDIR}"/infiles.list
+cd "${WDIR}" || exit 1
 xgettext --from-code=UTF-8 -C -kde -ci18n -ki18n:1 -ki18nc:1c,2 -ki18np:1,2 -ki18ncp:1c,2,3 -ktr2i18n:1 \
 	-kI18N_NOOP:1 -kI18N_NOOP2:1c,2 -kaliasLocale -kki18n:1 -kki18nc:1c,2 -kki18np:1,2 -kki18ncp:1c,2,3 \
 	--msgid-bugs-address="${BUGADDR}" \
-	--files-from=infiles.list -D ${BASEDIR} -D ${WDIR} -o ${PROJECT}.pot || { echo "error while calling xgettext. aborting."; exit 1; }
+	--files-from=infiles.list -D ${BASEDIR} -D "${WDIR}" -o ${PROJECT}.pot || { echo "error while calling xgettext. aborting."; exit 1; }
 echo "Done extracting messages"
 
 
 echo "Merging translations"
-catalogs=`find . -name '*.po'`
+catalogs=$(find . -name '*.po')
 for cat in $catalogs; do
-  echo $cat
-  msgmerge -o $cat.new $cat ${PROJECT}.pot
-  mv $cat.new $cat
+  echo "$cat"
+  msgmerge -o "$cat".new "$cat" ${PROJECT}.pot
+  mv "$cat".new "$cat"
 done
 echo "Done merging translations"
 
 
 echo "Cleaning up"
-cd ${WDIR}
+cd "${WDIR}" || exit 1
 rm infiles.list
 echo "Done"

--- a/translations/po/plasma_applet_org.kde.plasma.ambientnoise_en.po
+++ b/translations/po/plasma_applet_org.kde.plasma.ambientnoise_en.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: http://github.com/m-pilia/plasma-applet-ambientnoise/"
 "issues\n"
-"POT-Creation-Date: 2017-06-18 14:15+0200\n"
+"POT-Creation-Date: 2019-02-16 22:19+0100\n"
 "PO-Revision-Date: 2017-06-18 14:15+0200\n"
 "Last-Translator: Martino Pilia <martino.pilia@gmail.com>\n"
 "Language-Team: it <martino.pilia@gmail.com>\n"
@@ -18,14 +18,43 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 
 #: ../plasmoid/contents/config/config.qml:24
-#: ../plasmoid/contents/ui/main.qml:37
 msgid "Ambient noise"
 msgstr ""
 
-#: ../plasmoid/contents/ui/AddNoisePopup.qml:30
+#: ../plasmoid/contents/ui/main.qml:38
+msgid "Volume"
+msgstr ""
+
+#: ../plasmoid/contents/ui/main.qml:39
+msgid "Playing 1 noise"
+msgid_plural "Playing %1 noises"
+msgstr[0] ""
+msgstr[1] ""
+
+#: ../plasmoid/contents/ui/main.qml:39
+msgid "Paused"
+msgstr ""
+
+#: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
+msgid "Pause"
+msgstr ""
+
+#: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
+msgid "Play"
+msgstr ""
+
+#: ../plasmoid/contents/ui/main.qml:122
 msgid "Add a noise component"
 msgstr ""
 
-#: ../plasmoid/contents/ui/settings.qml:39
+#: ../plasmoid/contents/ui/settings.qml:40
 msgid "Noise data folder"
+msgstr ""
+
+#: ../plasmoid/contents/ui/settings.qml:53
+msgid "Restore default"
+msgstr ""
+
+#: ../plasmoid/contents/ui/settings.qml:63
+msgid "Paused at start-up"
 msgstr ""

--- a/translations/po/plasma_applet_org.kde.plasma.ambientnoise_it.po
+++ b/translations/po/plasma_applet_org.kde.plasma.ambientnoise_it.po
@@ -1,14 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Italian translation file.
+# Copyright (C) 2019 Martino Pilia
+# This file is distributed under the same license as the Ambient Noise package.
+# Martino Pilia <martino.pilia@gmail.com>, 2019.
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: http://github.com/m-pilia/plasma-applet-ambientnoise/"
 "issues\n"
-"POT-Creation-Date: 2017-06-18 14:15+0200\n"
+"POT-Creation-Date: 2019-02-16 22:19+0100\n"
 "PO-Revision-Date: 2017-06-18 14:15+0200\n"
 "Last-Translator: Martino Pilia <martino.pilia@gmail.com>\n"
 "Language-Team: it <martino.pilia@gmail.com>\n"
@@ -16,16 +16,46 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../plasmoid/contents/config/config.qml:24
-#: ../plasmoid/contents/ui/main.qml:37
 msgid "Ambient noise"
 msgstr "Rumore ambientale"
 
-#: ../plasmoid/contents/ui/AddNoisePopup.qml:30
+#: ../plasmoid/contents/ui/main.qml:38
+msgid "Volume"
+msgstr "Volume"
+
+#: ../plasmoid/contents/ui/main.qml:39
+msgid "Playing 1 noise"
+msgid_plural "Playing %1 noises"
+msgstr[0] "Riproducendo 1 rumore"
+msgstr[1] "Riproducendo %1 rumori"
+
+#: ../plasmoid/contents/ui/main.qml:39
+msgid "Paused"
+msgstr "In pausa"
+
+#: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
+msgid "Pause"
+msgstr "Pausa"
+
+#: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
+msgid "Play"
+msgstr "Riproduci"
+
+#: ../plasmoid/contents/ui/main.qml:122
 msgid "Add a noise component"
 msgstr "Aggiungi una componente di rumore"
 
-#: ../plasmoid/contents/ui/settings.qml:39
+#: ../plasmoid/contents/ui/settings.qml:40
 msgid "Noise data folder"
-msgstr "Cartella file di rumore"
+msgstr "Cartella contenente i file di rumore"
+
+#: ../plasmoid/contents/ui/settings.qml:53
+msgid "Restore default"
+msgstr "Ripristina valore predefinito"
+
+#: ../plasmoid/contents/ui/settings.qml:63
+msgid "Paused at start-up"
+msgstr "In pausa all'avvio"

--- a/translations/po/plasma_applet_org.kde.plasma.ambientnoise_sv.po
+++ b/translations/po/plasma_applet_org.kde.plasma.ambientnoise_sv.po
@@ -1,62 +1,61 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# Swedish translation file.
+# Copyright (C) 2019 Martino Pilia
+# This file is distributed under the same license as the Ambient Noise package.
+# Martino Pilia <martino.pilia@gmail.com>, 2019.
 #
-#, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: 0.1\n"
 "Report-Msgid-Bugs-To: http://github.com/m-pilia/plasma-applet-ambientnoise/"
 "issues\n"
 "POT-Creation-Date: 2019-02-16 22:19+0100\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
-"Language: \n"
+"PO-Revision-Date: 2017-06-18 14:15+0200\n"
+"Last-Translator: Martino Pilia <martino.pilia@gmail.com>\n"
+"Language-Team: sv <martino.pilia@gmail.com>\n"
+"Language: sv\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: ../plasmoid/contents/config/config.qml:24
 msgid "Ambient noise"
-msgstr ""
+msgstr "Omgivande ljud"
 
 #: ../plasmoid/contents/ui/main.qml:38
 msgid "Volume"
-msgstr ""
+msgstr "Volym"
 
 #: ../plasmoid/contents/ui/main.qml:39
 msgid "Playing 1 noise"
 msgid_plural "Playing %1 noises"
-msgstr[0] ""
-msgstr[1] ""
+msgstr[0] "Spelar 1 ljud"
+msgstr[1] "Spelar %1 ljud"
 
 #: ../plasmoid/contents/ui/main.qml:39
 msgid "Paused"
-msgstr ""
+msgstr "Pausad"
 
 #: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
 msgid "Pause"
-msgstr ""
+msgstr "Pausa"
 
 #: ../plasmoid/contents/ui/main.qml:72 ../plasmoid/contents/ui/main.qml:76
 msgid "Play"
-msgstr ""
+msgstr "Spela"
 
 #: ../plasmoid/contents/ui/main.qml:122
 msgid "Add a noise component"
-msgstr ""
+msgstr "Lägga till ett ljud"
 
 #: ../plasmoid/contents/ui/settings.qml:40
 msgid "Noise data folder"
-msgstr ""
+msgstr "Ljud mapp"
 
 #: ../plasmoid/contents/ui/settings.qml:53
 msgid "Restore default"
-msgstr ""
+msgstr "Återställa förvalt"
 
 #: ../plasmoid/contents/ui/settings.qml:63
 msgid "Paused at start-up"
-msgstr ""
+msgstr "Pausad vid start"


### PR DESCRIPTION
Keep status across reboots, including play/pause status, volume, and
active noise components. The status is stored in the plasmoid settings.

Side changes:
* Change volume with mouse wheel from compact representation.
* Lint translations/extract-message.sh script.
* Update Italian translation.
* Add Swedish translation.

Resolves #9